### PR TITLE
Fixing assertion from stuck items in high contention race condition

### DIFF
--- a/src/main/java/com/amazonaws/services/dynamodbv2/transactions/TransactionItem.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/transactions/TransactionItem.java
@@ -477,22 +477,19 @@ class TransactionItem {
 
     /**
      * Marks the transaction item as either COMMITTED or ROLLED_BACK, but only if it was in the PENDING state.
-     * If expectedVersion is passed in, it will also condition on the expected version. 
+     * It will also condition on the expected version. 
      * 
      * @param targetState
-     * @param expectedVersion an optional OCC check for the Version field
+     * @param expectedVersion 
      * @throws ConditionalCheckFailedException if the transaction doesn't exist, isn't PENDING, is finalized, 
      *         or the expected version doesn't match (if specified)  
      */
-    public void finish(final State targetState, final Integer expectedVersion) throws ConditionalCheckFailedException {
+    public void finish(final State targetState, final int expectedVersion) throws ConditionalCheckFailedException {
         txAssert(State.COMMITTED.equals(targetState) || State.ROLLED_BACK.equals(targetState),"Illegal state in finish(): " + targetState, "txItem", txItem);
-        
         Map<String, ExpectedAttributeValue> expected = new HashMap<String, ExpectedAttributeValue>(2);
         expected.put(AttributeName.STATE.toString(), new ExpectedAttributeValue().withValue(new AttributeValue().withS(STATE_PENDING)));
         expected.put(AttributeName.FINALIZED.toString(), new ExpectedAttributeValue().withExists(false));
-        if(expectedVersion != null) {
-            expected.put(AttributeName.VERSION.toString(), new ExpectedAttributeValue().withValue(new AttributeValue().withN(expectedVersion.toString())));    
-        }
+        expected.put(AttributeName.VERSION.toString(), new ExpectedAttributeValue().withValue(new AttributeValue().withN(Integer.toString(expectedVersion))));
         
         Map<String, AttributeValueUpdate> updates = new HashMap<String, AttributeValueUpdate>();
         updates.put(AttributeName.STATE.toString(), new AttributeValueUpdate()


### PR DESCRIPTION
Fixing assertion trying to release lock in race condition with high contention. The assertion resulted in an item that was stuck and locked by a previous transaction, but was in a safe state consistent with all other items in the transaction.

The resulting exception had the message: 'Item should not have been applied.  Unable to release lock'. This exception resulted in an item that could not be unlocked automatically by the library. However when an item got into this state, the transaction lock attributes could safely be deleted from the stuck item manually, and future transactions involving this item would continue.

This change makes all operations to the Transaction Item use conditional writes on the version number, whereas before there was one unlock case that was trying to be too clever and use other conditions instead of the version number.