### PR TITLE
Read Isolation for Scan/Query/BatchGetItem

### DIFF
--- a/integration/src/test/java/com/amazonaws/services/dynamodbv2/transactions/TransactionManagerDBFacadeIntegrationTest.java
+++ b/integration/src/test/java/com/amazonaws/services/dynamodbv2/transactions/TransactionManagerDBFacadeIntegrationTest.java
@@ -1,0 +1,326 @@
+/**
+ * Copyright 2013-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Amazon Software License (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/asl/
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express
+ * or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package com.amazonaws.services.dynamodbv2.transactions;
+
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.AttributeValueUpdate;
+import com.amazonaws.services.dynamodbv2.model.BatchGetItemRequest;
+import com.amazonaws.services.dynamodbv2.model.BatchGetItemResult;
+import com.amazonaws.services.dynamodbv2.model.ComparisonOperator;
+import com.amazonaws.services.dynamodbv2.model.Condition;
+import com.amazonaws.services.dynamodbv2.model.GetItemRequest;
+import com.amazonaws.services.dynamodbv2.model.GetItemResult;
+import com.amazonaws.services.dynamodbv2.model.KeysAndAttributes;
+import com.amazonaws.services.dynamodbv2.model.PutItemRequest;
+import com.amazonaws.services.dynamodbv2.model.QueryRequest;
+import com.amazonaws.services.dynamodbv2.model.QueryResult;
+import com.amazonaws.services.dynamodbv2.model.ScanRequest;
+import com.amazonaws.services.dynamodbv2.model.ScanResult;
+import com.amazonaws.services.dynamodbv2.model.UpdateItemRequest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
+public class TransactionManagerDBFacadeIntegrationTest extends IntegrationTest {
+
+    private TransactionManagerDynamoDBFacade uncommittedFacade;
+    private TransactionManagerDynamoDBFacade committedFacade;
+
+    private Map<String, AttributeValueUpdate> update;
+    private Map<String, AttributeValue> item0Updated;
+    private Map<String, AttributeValue> item0Filtered; // item0 with only the attributesToGet
+    private List<String> attributesToGet;
+
+    public TransactionManagerDBFacadeIntegrationTest() {
+        super();
+    }
+
+    @Before
+    public void setup() {
+        dynamodb.reset();
+        uncommittedFacade = new TransactionManagerDynamoDBFacade(manager, Transaction.IsolationLevel.UNCOMMITTED);
+        committedFacade = new TransactionManagerDynamoDBFacade(manager, Transaction.IsolationLevel.COMMITTED);
+        key0 = newKey(INTEG_HASH_TABLE_NAME);
+        item0 = new HashMap<String, AttributeValue>(key0);
+        item0.put("s_someattr", new AttributeValue("val"));
+        item0Filtered = new HashMap<String, AttributeValue>(item0);
+        item0.put("attr_not_to_get", new AttributeValue("val_not_to_get"));
+        attributesToGet = Arrays.asList(ID_ATTRIBUTE, "s_someattr"); // not including attr_not_to_get
+        update = Collections.singletonMap(
+                "s_someattr",
+                new AttributeValueUpdate().withValue(new AttributeValue("val2")));
+        item0Updated = new HashMap<String, AttributeValue>(item0);
+        item0Updated.put("s_someattr", new AttributeValue("val2"));
+    }
+
+    @After
+    public void cleanup() throws InterruptedException {
+        deleteTables();
+        createTables();
+        dynamodb.reset();
+    }
+
+    private void putItem(final boolean commit) {
+        Transaction t = manager.newTransaction();
+        t.putItem(new PutItemRequest()
+                .withTableName(INTEG_HASH_TABLE_NAME)
+                .withItem(item0));
+        if (commit) {
+            t.commit();
+            assertItemNotLocked(INTEG_HASH_TABLE_NAME, key0, true);
+        } else {
+            assertItemLocked(INTEG_HASH_TABLE_NAME, key0, t.getId(), true, true);
+        }
+    }
+
+    private void updateItem(final boolean commit) {
+        Transaction t = manager.newTransaction();
+        UpdateItemRequest request = new UpdateItemRequest()
+                .withTableName(INTEG_HASH_TABLE_NAME)
+                .withKey(key0)
+                .withAttributeUpdates(update);
+        t.updateItem(request);
+        if (commit) {
+            t.commit();
+            assertItemNotLocked(INTEG_HASH_TABLE_NAME, key0, true);
+        } else {
+            assertItemLocked(INTEG_HASH_TABLE_NAME, key0, t.getId(), false, true);
+        }
+    }
+
+    private void assertContainsNoTransactionAttributes(final Map<String, AttributeValue> item) {
+        assertFalse(Transaction.isLocked(item));
+        assertFalse(Transaction.isApplied(item));
+        assertFalse(Transaction.isTransient(item));
+    }
+
+    private QueryRequest createQueryRequest(final boolean filterAttributes) {
+        Condition hashKeyCondition = new Condition()
+                .withComparisonOperator(ComparisonOperator.EQ)
+                .withAttributeValueList(key0.get(ID_ATTRIBUTE));
+        QueryRequest request = new QueryRequest()
+                .withTableName(INTEG_HASH_TABLE_NAME)
+                .withKeyConditions(Collections.singletonMap(ID_ATTRIBUTE, hashKeyCondition));
+        if (filterAttributes) {
+            request.setAttributesToGet(attributesToGet);
+        }
+        return request;
+    }
+
+    private BatchGetItemRequest createBatchGetItemRequest(final boolean filterAttributes) {
+        KeysAndAttributes keysAndAttributes = new KeysAndAttributes()
+                .withKeys(key0);
+        if (filterAttributes) {
+            keysAndAttributes.withAttributesToGet(attributesToGet);
+        }
+        return new BatchGetItemRequest()
+                .withRequestItems(
+                        Collections.singletonMap(
+                                INTEG_HASH_TABLE_NAME,
+                                keysAndAttributes));
+    }
+
+    private void testGetItemContainsItem(
+            final TransactionManagerDynamoDBFacade facade,
+            final Map<String, AttributeValue> item,
+            final boolean filterAttributes) {
+        GetItemRequest request = new GetItemRequest()
+                .withTableName(INTEG_HASH_TABLE_NAME)
+                .withKey(key0);
+        if (filterAttributes) {
+            request.setAttributesToGet(attributesToGet);
+        }
+        GetItemResult result = facade.getItem(request);
+        assertContainsNoTransactionAttributes(result.getItem());
+        assertEquals(item, result.getItem());
+    }
+
+    private void testScanContainsItem(
+            final TransactionManagerDynamoDBFacade facade,
+            final Map<String, AttributeValue> item,
+            final boolean filterAttributes) {
+        ScanRequest scanRequest = new ScanRequest()
+                .withTableName(INTEG_HASH_TABLE_NAME);
+        if (filterAttributes) {
+            scanRequest.setAttributesToGet(attributesToGet);
+        }
+        ScanResult scanResult = facade.scan(scanRequest);
+        assertEquals(1, scanResult.getItems().size());
+        assertContainsNoTransactionAttributes(scanResult.getItems().get(0));
+        assertEquals(item, scanResult.getItems().get(0));
+    }
+
+    private void testScanIsEmpty(final TransactionManagerDynamoDBFacade facade) {
+        ScanResult scanResult = facade.scan(new ScanRequest()
+                .withTableName(INTEG_HASH_TABLE_NAME));
+        assertNotNull(scanResult.getItems());
+        assertEquals(0, scanResult.getItems().size());
+    }
+
+    private void testQueryContainsItem(
+            final TransactionManagerDynamoDBFacade facade,
+            final Map<String, AttributeValue> item,
+            final boolean filterAttributes) {
+        QueryRequest queryRequest = createQueryRequest(filterAttributes);
+        QueryResult queryResult = facade.query(queryRequest);
+        assertEquals(1, queryResult.getItems().size());
+        assertContainsNoTransactionAttributes(queryResult.getItems().get(0));
+        assertEquals(item, queryResult.getItems().get(0));
+    }
+
+    private void testQueryIsEmpty(final TransactionManagerDynamoDBFacade facade) {
+        QueryRequest queryRequest = createQueryRequest(false);
+        QueryResult queryResult = facade.query(queryRequest);
+        assertNotNull(queryResult.getItems());
+        assertEquals(0, queryResult.getItems().size());
+    }
+
+    private void testBatchGetItemsContainsItem(
+            final TransactionManagerDynamoDBFacade facade,
+            final Map<String, AttributeValue> item,
+            final boolean filterAttributes) {
+        BatchGetItemRequest batchGetItemRequest = createBatchGetItemRequest(filterAttributes);
+        BatchGetItemResult batchGetItemResult = facade.batchGetItem(batchGetItemRequest);
+        List<Map<String, AttributeValue>> items = batchGetItemResult.getResponses().get(INTEG_HASH_TABLE_NAME);
+        assertEquals(1, items.size());
+        assertContainsNoTransactionAttributes(items.get(0));
+        assertEquals(item, items.get(0));
+    }
+
+    private void testBatchGetItemsIsEmpty(final TransactionManagerDynamoDBFacade facade) {
+        BatchGetItemRequest batchGetItemRequest = createBatchGetItemRequest(false);
+        BatchGetItemResult batchGetItemResult = facade.batchGetItem(batchGetItemRequest);
+        assertNotNull(batchGetItemResult.getResponses());
+        assertEquals(1, batchGetItemResult.getResponses().size());
+        assertNotNull(batchGetItemResult.getResponses().get(INTEG_HASH_TABLE_NAME));
+        assertEquals(0, batchGetItemResult.getResponses().get(INTEG_HASH_TABLE_NAME).size());
+
+    }
+
+    /**
+     * Test that calls to scan, query, getItem, and batchGetItems contain
+     * the expected result.
+     * @param facade The facade to test
+     * @param item The expected item to be found
+     * @param filterAttributes Whether or not to filter attributes using attributesToGet
+     */
+    private void testReadCallsContainItem(
+            final TransactionManagerDynamoDBFacade facade,
+            final Map<String, AttributeValue> item,
+            final boolean filterAttributes) {
+
+        // GetItem contains the expected result
+        testGetItemContainsItem(facade, item, filterAttributes);
+
+        // Scan contains the expected result
+        testScanContainsItem(facade, item, filterAttributes);
+
+        // Query contains the expected result
+        testQueryContainsItem(facade, item, filterAttributes);
+
+        // BatchGetItems contains the expected result
+        testBatchGetItemsContainsItem(facade, item, filterAttributes);
+    }
+
+    private void testReadCallsReturnEmpty(final TransactionManagerDynamoDBFacade facade) {
+
+        // GetItem contains null
+        testGetItemContainsItem(facade, null, false);
+
+        // Scan returns empty
+        testScanIsEmpty(facade);
+
+        // Query returns empty
+        testQueryIsEmpty(facade);
+
+        // BatchGetItems does not return item
+        testBatchGetItemsIsEmpty(facade);
+    }
+
+    @Test
+    public void uncommittedFacadeReadsItemIfCommitted() {
+        putItem(true);
+
+        // test that read calls contain the committed item
+        testReadCallsContainItem(uncommittedFacade, item0, false);
+
+        // test that read calls contain the committed item respecting attributesToGet
+        testReadCallsContainItem(uncommittedFacade, item0Filtered, true);
+    }
+
+    @Test
+    public void uncommittedFacadeReadsItemIfNotCommitted() {
+        putItem(false);
+
+        // test that read calls contain the uncommitted item
+        testReadCallsContainItem(uncommittedFacade, item0, false);
+
+        // test that read calls contain the uncommitted item respecting attributesToGet
+        testReadCallsContainItem(uncommittedFacade, item0Filtered, true);
+    }
+
+    @Test
+    public void uncommittedFacadeReadsUncommittedUpdate() {
+        putItem(true);
+        updateItem(false);
+
+        // test that read calls contain the updated uncommitted item
+        testReadCallsContainItem(uncommittedFacade, item0Updated, false);
+    }
+
+    @Test
+    public void committedFacadeReadsCommittedItem() {
+        putItem(true);
+
+        // test that read calls contain the committed item
+        testReadCallsContainItem(committedFacade, item0, false);
+
+        // test that read calls contain the committed item respecting attributesToGet
+        testReadCallsContainItem(committedFacade, item0Filtered, true);
+    }
+
+    @Test
+    public void committedFacadeDoesNotReadUncommittedItem() {
+        putItem(false);
+
+        // test that read calls do not contain the uncommitted item
+        testReadCallsReturnEmpty(committedFacade);
+    }
+
+    @Test
+    public void committedFacadeDoesNotReadUncommittedUpdate() {
+        putItem(true);
+        updateItem(false);
+
+        // test that read calls contain the last committed version of the item
+        testReadCallsContainItem(committedFacade, item0, false);
+
+        // test that read calls contain the last committed version of the item
+        // respecting attributesToGet
+        testReadCallsContainItem(committedFacade, item0Filtered, true);
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,13 @@
             <version>4.11</version>
             <optional>true</optional>
         </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>1.9.5</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     </licenses>
 
     <properties>
-        <aws-java-sdk.version>1.9.16</aws-java-sdk.version>
+        <aws-java-sdk.version>1.11.31</aws-java-sdk.version>
     </properties>
 
     <dependencies>

--- a/src/main/java/com/amazonaws/services/dynamodbv2/transactions/ReadCommittedIsolationHandlerImpl.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/transactions/ReadCommittedIsolationHandlerImpl.java
@@ -1,0 +1,219 @@
+/**
+ * Copyright 2013-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Amazon Software License (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/asl/
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express
+ * or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package com.amazonaws.services.dynamodbv2.transactions;
+
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.GetItemRequest;
+import com.amazonaws.services.dynamodbv2.transactions.exceptions.TransactionException;
+import com.amazonaws.services.dynamodbv2.transactions.exceptions.TransactionNotFoundException;
+import com.amazonaws.services.dynamodbv2.transactions.exceptions.UnknownCompletedTransactionException;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.amazonaws.services.dynamodbv2.transactions.Transaction.getOwner;
+import static com.amazonaws.services.dynamodbv2.transactions.Transaction.isApplied;
+import static com.amazonaws.services.dynamodbv2.transactions.Transaction.isTransient;
+import static com.amazonaws.services.dynamodbv2.transactions.exceptions.TransactionAssertionException.txAssert;
+
+/**
+ * An isolation handler for reading items at the committed
+ * (Transaction.IsolationLevel.COMMITTED) level. It will
+ * filter out transient items. If there is an applied, but
+ * uncommitted item, the isolation handler will attempt to
+ * get the last committed version of the item.
+ */
+public class ReadCommittedIsolationHandlerImpl implements ReadIsolationHandler {
+
+    private static final int DEFAULT_NUM_RETRIES = 2;
+    private static final Log LOG = LogFactory.getLog(ReadCommittedIsolationHandlerImpl.class);
+
+    private final TransactionManager txManager;
+    private final int numRetries;
+
+    public ReadCommittedIsolationHandlerImpl(final TransactionManager txManager) {
+        this(txManager, DEFAULT_NUM_RETRIES);
+    }
+
+    public ReadCommittedIsolationHandlerImpl(final TransactionManager txManager, final int numRetries) {
+        this.txManager = txManager;
+        this.numRetries = numRetries;
+    }
+
+    /**
+     * Return the item that's passed in if it's not locked. Otherwise, throw a TransactionException.
+     * @param item The item to check
+     * @return The item if it's locked (or if it's locked, but not yet applied)
+     */
+    protected Map<String, AttributeValue> checkItemCommitted(final Map<String, AttributeValue> item) {
+        // If the item doesn't exist, it's not locked
+        if (item == null) {
+            return null;
+        }
+        // If the item is transient, return null
+        if (isTransient(item)) {
+            return null;
+        }
+        // If the item isn't applied, it doesn't matter if it's locked
+        if (!isApplied(item)) {
+            return item;
+        }
+        // If the item isn't locked, return it
+        String lockingTxId = getOwner(item);
+        if (lockingTxId == null) {
+            return item;
+        }
+
+        throw new TransactionException(lockingTxId, "Item has been modified in an uncommitted transaction.");
+    }
+
+    /**
+     * Get an old committed version of an item from the images table.
+     * @param lockingTx The transaction that is currently locking the item.
+     * @param tableName The table that contains the item
+     * @param key The item's key
+     * @return a previously committed version of the item
+     */
+    protected Map<String, AttributeValue> getOldCommittedItem(
+            final Transaction lockingTx,
+            final String tableName,
+            final Map<String, AttributeValue> key) {
+        Request lockingRequest = lockingTx.getTxItem().getRequestForKey(tableName, key);
+        txAssert(lockingRequest != null, null, "Expected transaction to be locking request, but no request found for tx", lockingTx.getId(), "table", tableName, "key ", key);
+        Map<String, AttributeValue> oldItem = lockingTx.getTxItem().loadItemImage(lockingRequest.getRid());
+        if (oldItem == null) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Item image " + lockingRequest.getRid() + " missing for transaction " + lockingTx.getId());
+            }
+            throw new UnknownCompletedTransactionException(
+                    lockingTx.getId(),
+                    "Transaction must have completed since the old copy of the image is missing");
+        }
+        return oldItem;
+    }
+
+    /**
+     * Create a GetItemRequest for an item (in the event that you need to get the item again).
+     * @param tableName The table that holds the item
+     * @param item The item to get
+     * @return the request
+     */
+    protected GetItemRequest createGetItemRequest(
+            final String tableName,
+            final Map<String, AttributeValue> item) {
+        Map<String, AttributeValue> key = txManager.createKeyMap(tableName, item);
+
+        /*
+         * Set the request to consistent read the next time around, since we may have read while locking tx
+         * was cleaning up or read a stale item that is no longer locked
+         */
+        GetItemRequest request = new GetItemRequest()
+                .withTableName(tableName)
+                .withKey(key)
+                .withConsistentRead(true);
+        return request;
+    }
+
+    protected Transaction loadTransaction(String txId) {
+        return new Transaction(txId, txManager, false);
+    }
+
+    /**
+     * Returns the item that's passed in if it's not locked. Otherwise, tries to get an old
+     * committed version of the item. If that's not possible, it retries.
+     * @param item The item to check.
+     * @param tableName The table that contains the item
+     * @return A committed version of the item (not necessarily the latest committed version).
+     */
+    protected Map<String, AttributeValue> handleItem(
+            final Map<String, AttributeValue> item,
+            final String tableName,
+            final int numRetries) {
+        GetItemRequest request = null; // only create if necessary
+        for (int i = 0; i <= numRetries; i++) {
+            final Map<String, AttributeValue> currentItem;
+            if (i == 0) {
+                currentItem = item;
+            } else {
+                if (request == null) {
+                    request = createGetItemRequest(tableName, item);
+                }
+                currentItem = txManager.getClient().getItem(request).getItem();
+            }
+
+            // 1. Return the item if it isn't locked (or if it's locked, but not applied yet)
+            try {
+                return checkItemCommitted(currentItem);
+            } catch (TransactionException e1) {
+                try {
+                    // 2. Load the locking transaction
+                    Transaction lockingTx = loadTransaction(e1.getTxId());
+
+                    /*
+                     * 3. See if the locking transaction has been committed. If so, return the item. This is valid because you cannot
+                     * write to an item multiple times in the same transaction. Otherwise it would expose intermediate state.
+                     */
+                    if (TransactionItem.State.COMMITTED.equals(lockingTx.getTxItem().getState())) {
+                        return currentItem;
+                    }
+
+                    // 4. Try to get a previously committed version of the item
+                    if (request == null) {
+                        request = createGetItemRequest(tableName, item);
+                    }
+                    return getOldCommittedItem(lockingTx, tableName, request.getKey());
+                } catch (UnknownCompletedTransactionException e2) {
+                    LOG.debug("Could not find item image. Transaction must have already completed.", e2);
+                } catch (TransactionNotFoundException e2) {
+                    LOG.debug("Unable to find locking transaction. Transaction must have already completed.", e2);
+                }
+            }
+        }
+        throw new TransactionException(null, "Ran out of attempts to get a committed image of the item");
+    }
+
+    protected Map<String, AttributeValue> filterAttributesToGet(
+            final Map<String, AttributeValue> item,
+            final List<String> attributesToGet) {
+        if (item == null) {
+            return null;
+        }
+        if (attributesToGet == null || attributesToGet.isEmpty()) {
+            return item;
+        }
+        Map<String, AttributeValue> result = new HashMap<String, AttributeValue>();
+        for (String attributeName : attributesToGet) {
+            AttributeValue value = item.get(attributeName);
+            if (value != null) {
+                result.put(attributeName, value);
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public Map<String, AttributeValue> handleItem(
+            final Map<String, AttributeValue> item,
+            final List<String> attributesToGet,
+            final String tableName) {
+        return filterAttributesToGet(
+                handleItem(item, tableName, numRetries),
+                attributesToGet);
+    }
+
+}

--- a/src/main/java/com/amazonaws/services/dynamodbv2/transactions/ReadIsolationHandler.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/transactions/ReadIsolationHandler.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2013-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Amazon Software License (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/asl/
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express
+ * or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package com.amazonaws.services.dynamodbv2.transactions;
+
+
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * An isolation handler takes an item and returns a version
+ * of the item that can be read at the implemented isolaction
+ * level.
+ */
+public interface ReadIsolationHandler {
+
+    /**
+     * Returns a version of the item can be read at the isolation level implemented by
+     * the handler. This is possibly null if the item is transient. It might not be latest
+     * version if the isolation level is committed.
+     * @param item The item to check
+     * @param attributesToGet The attributes to get from the table. If null or empty, will
+     *                        fetch all attributes.
+     * @param tableName The table that contains the item
+     * @return A version of the item that can be read at the isolation level.
+     */
+    public Map<String, AttributeValue> handleItem(
+            final Map<String, AttributeValue> item,
+            final List<String> attributesToGet,
+            final String tableName);
+
+}

--- a/src/main/java/com/amazonaws/services/dynamodbv2/transactions/ReadUncommittedIsolationHandlerImpl.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/transactions/ReadUncommittedIsolationHandlerImpl.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2013-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Amazon Software License (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/asl/
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express
+ * or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package com.amazonaws.services.dynamodbv2.transactions;
+
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.amazonaws.services.dynamodbv2.transactions.Transaction.isApplied;
+import static com.amazonaws.services.dynamodbv2.transactions.Transaction.isTransient;
+
+/**
+ * An isolation handler for reading items at the uncommitted
+ * (Transaction.IsolationLevel.UNCOMMITTED) level. It will
+ * only filter out transient items.
+ */
+public class ReadUncommittedIsolationHandlerImpl implements ReadIsolationHandler {
+
+    private static final Log LOG = LogFactory.getLog(ReadUncommittedIsolationHandlerImpl.class);
+
+    /**
+     * Given an item, return whatever is there. The returned item may contain changes that will later be rolled back.
+     * If the item was inserted only for acquiring a lock (and the item will be gone after the transaction), the returned
+     * item will be null.
+     * @param item The item that the client read.
+     * @param attributesToGet The attributes to get from the table. If null or empty, will
+     *                        fetch all attributes.
+     * @param tableName the table that contains the item
+     * @return the item itself, unless it is transient and not applied.
+     */
+    @Override
+    public Map<String, AttributeValue> handleItem(
+            final Map<String, AttributeValue> item,
+            final List<String> attributesToGet,
+            final String tableName) {
+        // If the item doesn't exist, it's not locked
+        if (item == null) {
+            return null;
+        }
+
+        // If the item is transient, return a null item
+        // But if the change is applied, return it even if it was a transient item (delete and lock do not apply)
+        if (isTransient(item) && !isApplied(item)) {
+            return null;
+        }
+        return item;
+    }
+
+}

--- a/src/main/java/com/amazonaws/services/dynamodbv2/transactions/ThreadLocalDynamoDBFacade.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/transactions/ThreadLocalDynamoDBFacade.java
@@ -37,6 +37,8 @@ import com.amazonaws.services.dynamodbv2.model.DeleteItemRequest;
 import com.amazonaws.services.dynamodbv2.model.DeleteItemResult;
 import com.amazonaws.services.dynamodbv2.model.DeleteTableRequest;
 import com.amazonaws.services.dynamodbv2.model.DeleteTableResult;
+import com.amazonaws.services.dynamodbv2.model.DescribeLimitsRequest;
+import com.amazonaws.services.dynamodbv2.model.DescribeLimitsResult;
 import com.amazonaws.services.dynamodbv2.model.DescribeTableRequest;
 import com.amazonaws.services.dynamodbv2.model.DescribeTableResult;
 import com.amazonaws.services.dynamodbv2.model.GetItemRequest;
@@ -57,6 +59,7 @@ import com.amazonaws.services.dynamodbv2.model.UpdateItemResult;
 import com.amazonaws.services.dynamodbv2.model.UpdateTableRequest;
 import com.amazonaws.services.dynamodbv2.model.UpdateTableResult;
 import com.amazonaws.services.dynamodbv2.model.WriteRequest;
+import com.amazonaws.services.dynamodbv2.waiters.AmazonDynamoDBWaiters;
 
 /**
  * Necessary to work around a limitation of the mapper. The mapper always gets
@@ -279,5 +282,15 @@ public class ThreadLocalDynamoDBFacade implements AmazonDynamoDB {
     public BatchGetItemResult batchGetItem(Map<String, KeysAndAttributes> requestItems) throws AmazonServiceException, AmazonClientException {
         return getBackend().batchGetItem(requestItems);
     }
+
+	@Override
+	public DescribeLimitsResult describeLimits(DescribeLimitsRequest request) {
+		return getBackend().describeLimits(request);
+	}
+
+	@Override
+	public AmazonDynamoDBWaiters waiters() {
+		return getBackend().waiters();
+	}
 
 }

--- a/src/main/java/com/amazonaws/services/dynamodbv2/transactions/TransactionDynamoDBFacade.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/transactions/TransactionDynamoDBFacade.java
@@ -39,6 +39,8 @@ import com.amazonaws.services.dynamodbv2.model.DeleteItemRequest;
 import com.amazonaws.services.dynamodbv2.model.DeleteItemResult;
 import com.amazonaws.services.dynamodbv2.model.DeleteTableRequest;
 import com.amazonaws.services.dynamodbv2.model.DeleteTableResult;
+import com.amazonaws.services.dynamodbv2.model.DescribeLimitsRequest;
+import com.amazonaws.services.dynamodbv2.model.DescribeLimitsResult;
 import com.amazonaws.services.dynamodbv2.model.DescribeTableRequest;
 import com.amazonaws.services.dynamodbv2.model.DescribeTableResult;
 import com.amazonaws.services.dynamodbv2.model.ExpectedAttributeValue;
@@ -60,6 +62,7 @@ import com.amazonaws.services.dynamodbv2.model.UpdateItemResult;
 import com.amazonaws.services.dynamodbv2.model.UpdateTableRequest;
 import com.amazonaws.services.dynamodbv2.model.UpdateTableResult;
 import com.amazonaws.services.dynamodbv2.model.WriteRequest;
+import com.amazonaws.services.dynamodbv2.waiters.AmazonDynamoDBWaiters;
 
 /**
  * Facade for {@link AmazonDynamoDB} that forwards requests to a
@@ -442,5 +445,15 @@ public class TransactionDynamoDBFacade implements AmazonDynamoDB {
             throws AmazonServiceException, AmazonClientException {
         throw new UnsupportedOperationException("Use the underlying client instance instead");
     }
+
+	@Override
+	public DescribeLimitsResult describeLimits(DescribeLimitsRequest request) {
+		throw new UnsupportedOperationException("Use the underlying client instance instead");
+	}
+
+	@Override
+	public AmazonDynamoDBWaiters waiters() {
+		throw new UnsupportedOperationException("Use the underlying client instance instead");
+	}
 
 }

--- a/src/main/java/com/amazonaws/services/dynamodbv2/transactions/TransactionManagerDynamoDBFacade.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/transactions/TransactionManagerDynamoDBFacade.java
@@ -14,15 +14,12 @@
  */
 package com.amazonaws.services.dynamodbv2.transactions;
 
-import java.util.List;
-import java.util.Map;
-
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.AmazonWebServiceRequest;
 import com.amazonaws.ResponseMetadata;
 import com.amazonaws.regions.Region;
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.AbstractAmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.model.AttributeDefinition;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.model.AttributeValueUpdate;
@@ -37,8 +34,6 @@ import com.amazonaws.services.dynamodbv2.model.DeleteItemRequest;
 import com.amazonaws.services.dynamodbv2.model.DeleteItemResult;
 import com.amazonaws.services.dynamodbv2.model.DeleteTableRequest;
 import com.amazonaws.services.dynamodbv2.model.DeleteTableResult;
-import com.amazonaws.services.dynamodbv2.model.DescribeLimitsRequest;
-import com.amazonaws.services.dynamodbv2.model.DescribeLimitsResult;
 import com.amazonaws.services.dynamodbv2.model.DescribeTableRequest;
 import com.amazonaws.services.dynamodbv2.model.DescribeTableResult;
 import com.amazonaws.services.dynamodbv2.model.GetItemRequest;
@@ -60,20 +55,66 @@ import com.amazonaws.services.dynamodbv2.model.UpdateTableRequest;
 import com.amazonaws.services.dynamodbv2.model.UpdateTableResult;
 import com.amazonaws.services.dynamodbv2.model.WriteRequest;
 import com.amazonaws.services.dynamodbv2.transactions.Transaction.IsolationLevel;
-import com.amazonaws.services.dynamodbv2.waiters.AmazonDynamoDBWaiters;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Facade to support the DynamoDBMapper doing a read using a specific isolation
  * level. Used by {@link TransactionManager#load(Object, IsolationLevel)}.
  */
-public class TransactionManagerDynamoDBFacade implements AmazonDynamoDB {
+public class TransactionManagerDynamoDBFacade extends AbstractAmazonDynamoDB {
 
     private final TransactionManager txManager;
     private final IsolationLevel isolationLevel;
+    private final ReadIsolationHandler isolationHandler;
 
     public TransactionManagerDynamoDBFacade(TransactionManager txManager, IsolationLevel isolationLevel) {
         this.txManager = txManager;
         this.isolationLevel = isolationLevel;
+        this.isolationHandler = txManager.getReadIsolationHandler(isolationLevel);
+    }
+
+    /**
+     * Returns versions of the items can be read at the specified isolation level stripped of
+     * special attributes.
+     * @param items The items to check
+     * @param tableName The table that contains the item
+     * @param attributesToGet The attributes to get from the table. If null or empty, will
+     *                        fetch all attributes.
+     * @return Versions of the items that can be read at the isolation level stripped of special attributes
+     */
+    private List<Map<String, AttributeValue>> handleItems(
+            final List<Map<String, AttributeValue>> items,
+            final String tableName,
+            final List<String> attributesToGet) {
+        List<Map<String, AttributeValue>> result = new ArrayList<Map<String, AttributeValue>>();
+        for (Map<String, AttributeValue> item : items) {
+            Map<String, AttributeValue> handledItem = isolationHandler.handleItem(item, attributesToGet, tableName);
+            /**
+             * If the item is null, BatchGetItems, Scan, and Query should exclude the item from
+             * the returned list. This is based on the DynamoDB documentation.
+             */
+            if (handledItem != null) {
+                Transaction.stripSpecialAttributes(handledItem);
+                result.add(handledItem);
+            }
+        }
+        return result;
+    }
+
+    private Collection<String> addSpecialAttributes(Collection<String> attributesToGet) {
+        if (attributesToGet == null) {
+            return null;
+        }
+        Set<String> result = new HashSet<String>(attributesToGet);
+        result.addAll(Transaction.SPECIAL_ATTR_NAMES);
+        return result;
     }
 
     @Override
@@ -81,11 +122,11 @@ public class TransactionManagerDynamoDBFacade implements AmazonDynamoDB {
             throws AmazonServiceException, AmazonClientException {
         return txManager.getItem(request, isolationLevel);
     }
-    
+
     @Override
-    public GetItemResult getItem(String tableName,
-            Map<String, AttributeValue> key) throws AmazonServiceException,
-            AmazonClientException {
+    public GetItemResult getItem(
+            String tableName,
+            Map<String, AttributeValue> key) throws AmazonServiceException, AmazonClientException {
         return getItem(new GetItemRequest()
                 .withTableName(tableName)
                 .withKey(key));
@@ -102,6 +143,97 @@ public class TransactionManagerDynamoDBFacade implements AmazonDynamoDB {
     }
 
     @Override
+    public BatchGetItemResult batchGetItem(BatchGetItemRequest request)
+            throws AmazonServiceException, AmazonClientException {
+        for (KeysAndAttributes keysAndAttributes : request.getRequestItems().values()) {
+            Collection<String> attributesToGet = keysAndAttributes.getAttributesToGet();
+            keysAndAttributes.setAttributesToGet(addSpecialAttributes(attributesToGet));
+        }
+        BatchGetItemResult result = txManager.getClient().batchGetItem(request);
+        Map<String, List<Map<String, AttributeValue>>> responses = new HashMap<String, List<Map<String, AttributeValue>>>();
+        for (Map.Entry<String, List<Map<String, AttributeValue>>> e : result.getResponses().entrySet()) {
+            String tableName = e.getKey();
+            List<String> attributesToGet = request.getRequestItems().get(tableName).getAttributesToGet();
+            List<Map<String, AttributeValue>> items = handleItems(e.getValue(), tableName, attributesToGet);
+            responses.put(tableName, items);
+        }
+        result.setResponses(responses);
+        return result;
+    }
+
+    @Override
+    public BatchGetItemResult batchGetItem(
+            Map<String, KeysAndAttributes> requestItems,
+            String returnConsumedCapacity) throws AmazonServiceException,
+            AmazonClientException {
+        BatchGetItemRequest request = new BatchGetItemRequest()
+                .withRequestItems(requestItems)
+                .withReturnConsumedCapacity(returnConsumedCapacity);
+        return batchGetItem(request);
+    }
+
+    @Override
+    public BatchGetItemResult batchGetItem(
+            Map<String, KeysAndAttributes> requestItems)
+            throws AmazonServiceException, AmazonClientException {
+        BatchGetItemRequest request = new BatchGetItemRequest()
+                .withRequestItems(requestItems);
+        return batchGetItem(request);
+    }
+
+    @Override
+    public ScanResult scan(ScanRequest request) throws AmazonServiceException,
+            AmazonClientException {
+        Collection<String> attributesToGet = addSpecialAttributes(request.getAttributesToGet());
+        request.setAttributesToGet(attributesToGet);
+        ScanResult result = txManager.getClient().scan(request);
+        List<Map<String,AttributeValue>> items = handleItems(result.getItems(), request.getTableName(), request.getAttributesToGet());
+        result.setItems(items);
+        return result;
+    }
+
+    @Override
+    public ScanResult scan(String tableName, List<String> attributesToGet)
+            throws AmazonServiceException, AmazonClientException {
+        ScanRequest request = new ScanRequest()
+                .withTableName(tableName)
+                .withAttributesToGet(attributesToGet);
+        return scan(request);
+    }
+
+    @Override
+    public ScanResult scan(String tableName, Map<String, Condition> scanFilter)
+            throws AmazonServiceException, AmazonClientException {
+        ScanRequest request = new ScanRequest()
+                .withTableName(tableName)
+                .withScanFilter(scanFilter);
+        return scan(request);
+    }
+
+    @Override
+    public ScanResult scan(
+            String tableName,
+            List<String> attributesToGet,
+            Map<String, Condition> scanFilter) throws AmazonServiceException, AmazonClientException {
+        ScanRequest request = new ScanRequest()
+                .withTableName(tableName)
+                .withAttributesToGet(attributesToGet)
+                .withScanFilter(scanFilter);
+        return scan(request);
+    }
+
+    @Override
+    public QueryResult query(QueryRequest request) throws AmazonServiceException,
+            AmazonClientException {
+        Collection<String> attributesToGet = addSpecialAttributes(request.getAttributesToGet());
+        request.setAttributesToGet(attributesToGet);
+        QueryResult result = txManager.getClient().query(request);
+        List<Map<String, AttributeValue>> items = handleItems(result.getItems(), request.getTableName(), request.getAttributesToGet());
+        result.setItems(items);
+        return result;
+    }
+
+    @Override
     public PutItemResult putItem(PutItemRequest request)
             throws AmazonServiceException, AmazonClientException {
         throw new UnsupportedOperationException("Use the underlying client instance instead");
@@ -115,12 +247,6 @@ public class TransactionManagerDynamoDBFacade implements AmazonDynamoDB {
 
     @Override
     public DeleteItemResult deleteItem(DeleteItemRequest request)
-            throws AmazonServiceException, AmazonClientException {
-        throw new UnsupportedOperationException("Use the underlying client instance instead");
-    }
-
-    @Override
-    public BatchGetItemResult batchGetItem(BatchGetItemRequest arg0)
             throws AmazonServiceException, AmazonClientException {
         throw new UnsupportedOperationException("Use the underlying client instance instead");
     }
@@ -168,18 +294,6 @@ public class TransactionManagerDynamoDBFacade implements AmazonDynamoDB {
     }
 
     @Override
-    public QueryResult query(QueryRequest arg0) throws AmazonServiceException,
-            AmazonClientException {
-        throw new UnsupportedOperationException("Use the underlying client instance instead");
-    }
-
-    @Override
-    public ScanResult scan(ScanRequest arg0) throws AmazonServiceException,
-            AmazonClientException {
-        throw new UnsupportedOperationException("Use the underlying client instance instead");
-    }
-
-    @Override
     public void setEndpoint(String arg0) throws IllegalArgumentException {
         throw new UnsupportedOperationException("Use the underlying client instance instead");
     }
@@ -197,25 +311,6 @@ public class TransactionManagerDynamoDBFacade implements AmazonDynamoDB {
     @Override
     public UpdateTableResult updateTable(UpdateTableRequest arg0)
             throws AmazonServiceException, AmazonClientException {
-        throw new UnsupportedOperationException("Use the underlying client instance instead");
-    }
-
-    @Override
-    public ScanResult scan(String tableName, List<String> attributesToGet)
-            throws AmazonServiceException, AmazonClientException {
-        throw new UnsupportedOperationException("Use the underlying client instance instead");
-    }
-
-    @Override
-    public ScanResult scan(String tableName, Map<String, Condition> scanFilter)
-            throws AmazonServiceException, AmazonClientException {
-        throw new UnsupportedOperationException("Use the underlying client instance instead");
-    }
-
-    @Override
-    public ScanResult scan(String tableName, List<String> attributesToGet,
-            Map<String, Condition> scanFilter) throws AmazonServiceException,
-            AmazonClientException {
         throw new UnsupportedOperationException("Use the underlying client instance instead");
     }
 
@@ -316,30 +411,5 @@ public class TransactionManagerDynamoDBFacade implements AmazonDynamoDB {
             AmazonClientException {
         throw new UnsupportedOperationException("Use the underlying client instance instead");
     }
-
-    @Override
-    public BatchGetItemResult batchGetItem(
-            Map<String, KeysAndAttributes> requestItems,
-            String returnConsumedCapacity) throws AmazonServiceException,
-            AmazonClientException {
-        throw new UnsupportedOperationException("Use the underlying client instance instead");
-    }
-
-    @Override
-    public BatchGetItemResult batchGetItem(
-            Map<String, KeysAndAttributes> requestItems)
-            throws AmazonServiceException, AmazonClientException {
-        throw new UnsupportedOperationException("Use the underlying client instance instead");
-    }
-
-	@Override
-	public DescribeLimitsResult describeLimits(DescribeLimitsRequest arg0) {
-		throw new UnsupportedOperationException("Use the underlying client instance instead");
-	}
-
-	@Override
-	public AmazonDynamoDBWaiters waiters() {
-		throw new UnsupportedOperationException("Use the underlying client instance instead");
-	}
 
 }

--- a/src/main/java/com/amazonaws/services/dynamodbv2/transactions/TransactionManagerDynamoDBFacade.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/transactions/TransactionManagerDynamoDBFacade.java
@@ -37,6 +37,8 @@ import com.amazonaws.services.dynamodbv2.model.DeleteItemRequest;
 import com.amazonaws.services.dynamodbv2.model.DeleteItemResult;
 import com.amazonaws.services.dynamodbv2.model.DeleteTableRequest;
 import com.amazonaws.services.dynamodbv2.model.DeleteTableResult;
+import com.amazonaws.services.dynamodbv2.model.DescribeLimitsRequest;
+import com.amazonaws.services.dynamodbv2.model.DescribeLimitsResult;
 import com.amazonaws.services.dynamodbv2.model.DescribeTableRequest;
 import com.amazonaws.services.dynamodbv2.model.DescribeTableResult;
 import com.amazonaws.services.dynamodbv2.model.GetItemRequest;
@@ -58,6 +60,7 @@ import com.amazonaws.services.dynamodbv2.model.UpdateTableRequest;
 import com.amazonaws.services.dynamodbv2.model.UpdateTableResult;
 import com.amazonaws.services.dynamodbv2.model.WriteRequest;
 import com.amazonaws.services.dynamodbv2.transactions.Transaction.IsolationLevel;
+import com.amazonaws.services.dynamodbv2.waiters.AmazonDynamoDBWaiters;
 
 /**
  * Facade to support the DynamoDBMapper doing a read using a specific isolation
@@ -328,5 +331,15 @@ public class TransactionManagerDynamoDBFacade implements AmazonDynamoDB {
             throws AmazonServiceException, AmazonClientException {
         throw new UnsupportedOperationException("Use the underlying client instance instead");
     }
+
+	@Override
+	public DescribeLimitsResult describeLimits(DescribeLimitsRequest arg0) {
+		throw new UnsupportedOperationException("Use the underlying client instance instead");
+	}
+
+	@Override
+	public AmazonDynamoDBWaiters waiters() {
+		throw new UnsupportedOperationException("Use the underlying client instance instead");
+	}
 
 }

--- a/src/test/java/com/amazonaws/services/dynamodbv2/transactions/ReadCommittedIsolationHandlerImplUnitTest.java
+++ b/src/test/java/com/amazonaws/services/dynamodbv2/transactions/ReadCommittedIsolationHandlerImplUnitTest.java
@@ -1,0 +1,257 @@
+/**
+ * Copyright 2013-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Amazon Software License (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/asl/
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express
+ * or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package com.amazonaws.services.dynamodbv2.transactions;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.GetItemRequest;
+import com.amazonaws.services.dynamodbv2.model.GetItemResult;
+import com.amazonaws.services.dynamodbv2.transactions.TransactionItem.State;
+import com.amazonaws.services.dynamodbv2.transactions.exceptions.TransactionAssertionException;
+import com.amazonaws.services.dynamodbv2.transactions.exceptions.TransactionException;
+import com.amazonaws.services.dynamodbv2.transactions.exceptions.TransactionNotFoundException;
+import com.amazonaws.services.dynamodbv2.transactions.exceptions.UnknownCompletedTransactionException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static com.amazonaws.services.dynamodbv2.transactions.ReadUncommittedIsolationHandlerImplUnitTest.KEY;
+import static com.amazonaws.services.dynamodbv2.transactions.ReadUncommittedIsolationHandlerImplUnitTest.NON_TRANSIENT_APPLIED_ITEM;
+import static com.amazonaws.services.dynamodbv2.transactions.ReadUncommittedIsolationHandlerImplUnitTest.TABLE_NAME;
+import static com.amazonaws.services.dynamodbv2.transactions.ReadUncommittedIsolationHandlerImplUnitTest.TRANSIENT_APPLIED_ITEM;
+import static com.amazonaws.services.dynamodbv2.transactions.ReadUncommittedIsolationHandlerImplUnitTest.TRANSIENT_UNAPPLIED_ITEM;
+import static com.amazonaws.services.dynamodbv2.transactions.ReadUncommittedIsolationHandlerImplUnitTest.TX_ID;
+import static com.amazonaws.services.dynamodbv2.transactions.ReadUncommittedIsolationHandlerImplUnitTest.UNLOCKED_ITEM;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ReadCommittedIsolationHandlerImplUnitTest {
+
+    protected static final int RID = 1;
+    protected static GetItemRequest GET_ITEM_REQUEST = new GetItemRequest()
+            .withTableName(TABLE_NAME)
+            .withKey(KEY)
+            .withConsistentRead(true);
+
+    @Mock
+    private TransactionManager mockTxManager;
+
+    @Mock
+    private Transaction mockTx;
+
+    @Mock
+    private TransactionItem mockTxItem;
+
+    @Mock
+    private Request mockRequest;
+
+    @Mock
+    private AmazonDynamoDB mockClient;
+
+    private ReadCommittedIsolationHandlerImpl isolationHandler;
+
+    @Before
+    public void setup() {
+        isolationHandler = spy(new ReadCommittedIsolationHandlerImpl(mockTxManager, 0));
+        when(mockTx.getTxItem()).thenReturn(mockTxItem);
+        when(mockTx.getId()).thenReturn(TX_ID);
+        when(mockTxManager.getClient()).thenReturn(mockClient);
+    }
+
+    @Test
+    public void checkItemCommittedReturnsNullForNullItem() {
+        assertNull(isolationHandler.checkItemCommitted(null));
+    }
+
+    @Test
+    public void checkItemCommittedReturnsItemForUnlockedItem() {
+        assertEquals(UNLOCKED_ITEM, isolationHandler.checkItemCommitted(UNLOCKED_ITEM));
+    }
+
+    @Test
+    public void checkItemCommittedReturnsNullForTransientItem() {
+        assertNull(isolationHandler.checkItemCommitted(TRANSIENT_APPLIED_ITEM));
+        assertNull(isolationHandler.checkItemCommitted(TRANSIENT_UNAPPLIED_ITEM));
+    }
+
+    @Test(expected = TransactionException.class)
+    public void checkItemCommittedThrowsExceptionForNonTransientAppliedItem() {
+        isolationHandler.checkItemCommitted(NON_TRANSIENT_APPLIED_ITEM);
+    }
+
+    @Test
+    public void filterAttributesToGetReturnsNullForNullItem() {
+        isolationHandler.filterAttributesToGet(null, null);
+    }
+
+    @Test
+    public void filterAttributesToGetReturnsItemWhenAttributesToGetIsNull() {
+        Map<String, AttributeValue> result = isolationHandler.filterAttributesToGet(UNLOCKED_ITEM, null);
+        assertEquals(UNLOCKED_ITEM, result);
+    }
+
+    @Test
+    public void filterAttributesToGetReturnsItemWhenAttributesToGetIsEmpty() {
+        Map<String, AttributeValue> result = isolationHandler.filterAttributesToGet(UNLOCKED_ITEM, new ArrayList<String>());
+        assertEquals(UNLOCKED_ITEM, result);
+    }
+
+    @Test
+    public void filterAttributesToGetReturnsItemWhenAttributesToGetContainsAllAttributes() {
+        List<String> attributesToGet = Arrays.asList("Id", "attr1"); // all attributes
+        Map<String, AttributeValue> result = isolationHandler.filterAttributesToGet(UNLOCKED_ITEM, attributesToGet);
+        assertEquals(UNLOCKED_ITEM, result);
+    }
+
+    @Test
+    public void filterAttributesToGetReturnsOnlySpecifiedAttributesWhenSpecified() {
+        List<String> attributesToGet = Arrays.asList("Id"); // only keep the key
+        Map<String, AttributeValue> result = isolationHandler.filterAttributesToGet(UNLOCKED_ITEM, attributesToGet);
+        assertEquals(KEY, result);
+    }
+
+    @Test(expected = TransactionAssertionException.class)
+    public void getOldCommittedItemThrowsExceptionIfNoLockingRequestExists() {
+        when(mockTxItem.getRequestForKey(TABLE_NAME, KEY)).thenReturn(null);
+        isolationHandler.getOldCommittedItem(mockTx, TABLE_NAME, KEY);
+    }
+
+    @Test(expected = UnknownCompletedTransactionException.class)
+    public void getOldCommittedItemThrowsExceptionIfOldItemDoesNotExist() {
+        when(mockTxItem.getRequestForKey(TABLE_NAME, KEY)).thenReturn(mockRequest);
+        when(mockRequest.getRid()).thenReturn(RID);
+        when(mockTxItem.loadItemImage(RID)).thenReturn(null);
+        isolationHandler.getOldCommittedItem(mockTx, TABLE_NAME, KEY);
+    }
+
+    @Test
+    public void getOldCommittedItemReturnsOldImageIfOldItemExists() {
+        when(mockTxItem.getRequestForKey(TABLE_NAME, KEY)).thenReturn(mockRequest);
+        when(mockRequest.getRid()).thenReturn(RID);
+        when(mockTxItem.loadItemImage(RID)).thenReturn(UNLOCKED_ITEM);
+        Map<String, AttributeValue> result = isolationHandler.getOldCommittedItem(mockTx, TABLE_NAME, KEY);
+        assertEquals(UNLOCKED_ITEM, result);
+    }
+
+    @Test
+    public void createGetItemRequestCorrectlyCreatesRequest() {
+        when(mockTxManager.createKeyMap(TABLE_NAME, NON_TRANSIENT_APPLIED_ITEM)).thenReturn(KEY);
+        GetItemRequest request = isolationHandler.createGetItemRequest(TABLE_NAME, NON_TRANSIENT_APPLIED_ITEM);
+        assertEquals(TABLE_NAME, request.getTableName());
+        assertEquals(KEY, request.getKey());
+        assertEquals(null, request.getAttributesToGet());
+        assertTrue(request.getConsistentRead());
+    }
+
+    @Test
+    public void handleItemReturnsNullForNullItem() {
+        assertNull(isolationHandler.handleItem(null, TABLE_NAME, 0));
+    }
+
+    @Test
+    public void handleItemReturnsItemForUnlockedItem() {
+        assertEquals(UNLOCKED_ITEM, isolationHandler.handleItem(UNLOCKED_ITEM, TABLE_NAME, 0));
+    }
+
+    @Test
+    public void handleItemReturnsNullForTransientItem() {
+        assertNull(isolationHandler.handleItem(TRANSIENT_APPLIED_ITEM, TABLE_NAME, 0));
+        assertNull(isolationHandler.handleItem(TRANSIENT_UNAPPLIED_ITEM, TABLE_NAME, 0));
+    }
+
+    @Test(expected = TransactionException.class)
+    public void handleItemThrowsExceptionForNonTransientAppliedItemWithNoCorrespondingTx() {
+        doThrow(TransactionNotFoundException.class).when(isolationHandler).loadTransaction(TX_ID);
+        isolationHandler.handleItem(NON_TRANSIENT_APPLIED_ITEM, TABLE_NAME, 0);
+    }
+
+    @Test
+    public void handleItemReturnsItemForNonTransientAppliedItemWithCommittedTxItem() {
+        doReturn(mockTx).when(isolationHandler).loadTransaction(TX_ID);
+        when(mockTxItem.getState()).thenReturn(State.COMMITTED);
+        assertEquals(NON_TRANSIENT_APPLIED_ITEM, isolationHandler.handleItem(NON_TRANSIENT_APPLIED_ITEM, TABLE_NAME, 0));
+    }
+
+    @Test
+    public void handleItemReturnsOldVersionOfItemForNonTransientAppliedItemWithPendingTxItem() {
+        doReturn(mockTx).when(isolationHandler).loadTransaction(TX_ID);
+        doReturn(UNLOCKED_ITEM).when(isolationHandler).getOldCommittedItem(mockTx, TABLE_NAME, KEY);
+        when(mockTxManager.createKeyMap(TABLE_NAME, NON_TRANSIENT_APPLIED_ITEM)).thenReturn(KEY);
+        when(mockTxItem.getState()).thenReturn(State.PENDING);
+        when(mockTxItem.getRequestForKey(TABLE_NAME, KEY)).thenReturn(mockRequest);
+        assertEquals(UNLOCKED_ITEM, isolationHandler.handleItem(NON_TRANSIENT_APPLIED_ITEM, TABLE_NAME, 0));
+        verify(isolationHandler).loadTransaction(TX_ID);
+    }
+
+    @Test(expected = TransactionException.class)
+    public void handleItemThrowsExceptionForNonTransientAppliedItemWithPendingTxItemWithNoOldVersionAndNoRetries() {
+        doReturn(mockTx).when(isolationHandler).loadTransaction(TX_ID);
+        doThrow(UnknownCompletedTransactionException.class).when(isolationHandler).getOldCommittedItem(mockTx, TABLE_NAME, KEY);
+        when(mockTxItem.getState()).thenReturn(State.PENDING);
+        when(mockTxItem.getRequestForKey(TABLE_NAME, KEY)).thenReturn(mockRequest);
+        isolationHandler.handleItem(NON_TRANSIENT_APPLIED_ITEM, TABLE_NAME, 0);
+        verify(isolationHandler).loadTransaction(TX_ID);
+    }
+
+    @Test
+    public void handleItemRetriesWhenTransactionNotFound() {
+        doThrow(TransactionNotFoundException.class).when(isolationHandler).loadTransaction(TX_ID);
+        when(mockTxManager.createKeyMap(TABLE_NAME, NON_TRANSIENT_APPLIED_ITEM)).thenReturn(KEY);
+        when(mockClient.getItem(GET_ITEM_REQUEST)).thenReturn(new GetItemResult().withItem(NON_TRANSIENT_APPLIED_ITEM));
+        boolean caughtException = false;
+        try {
+            isolationHandler.handleItem(NON_TRANSIENT_APPLIED_ITEM, TABLE_NAME, 1);
+        } catch (TransactionException e) {
+            caughtException = true;
+        }
+        assertTrue(caughtException);
+        verify(isolationHandler, times(2)).loadTransaction(TX_ID);
+        verify(isolationHandler).createGetItemRequest(TABLE_NAME, NON_TRANSIENT_APPLIED_ITEM);
+        verify(mockClient).getItem(GET_ITEM_REQUEST);
+    }
+
+    @Test
+    public void handleItemRetriesWhenUnknownCompletedTransaction() {
+        doReturn(mockTx).when(isolationHandler).loadTransaction(TX_ID);
+        doThrow(UnknownCompletedTransactionException.class).when(isolationHandler).getOldCommittedItem(mockTx, TABLE_NAME, KEY);
+        when(mockTxManager.createKeyMap(TABLE_NAME, NON_TRANSIENT_APPLIED_ITEM)).thenReturn(KEY);
+        when(mockClient.getItem(GET_ITEM_REQUEST)).thenReturn(new GetItemResult().withItem(NON_TRANSIENT_APPLIED_ITEM));
+        boolean caughtException = false;
+        try {
+            isolationHandler.handleItem(NON_TRANSIENT_APPLIED_ITEM, TABLE_NAME, 1);
+        } catch (TransactionException e) {
+            caughtException = true;
+        }
+        assertTrue(caughtException);
+        verify(isolationHandler, times(2)).loadTransaction(TX_ID);
+        verify(isolationHandler).createGetItemRequest(TABLE_NAME, NON_TRANSIENT_APPLIED_ITEM);
+        verify(mockClient).getItem(GET_ITEM_REQUEST);
+    }
+}

--- a/src/test/java/com/amazonaws/services/dynamodbv2/transactions/ReadUncommittedIsolationHandlerImplUnitTest.java
+++ b/src/test/java/com/amazonaws/services/dynamodbv2/transactions/ReadUncommittedIsolationHandlerImplUnitTest.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2013-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Amazon Software License (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/asl/
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express
+ * or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package com.amazonaws.services.dynamodbv2.transactions;
+
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ReadUncommittedIsolationHandlerImplUnitTest {
+
+    protected static final String TABLE_NAME = "TEST_TABLE";
+    protected static final Map<String, AttributeValue> KEY = Collections.singletonMap("Id", new AttributeValue().withS("KeyValue"));
+    protected static final String TX_ID = "e1b52a78-0187-4787-b1a3-27f63a78898b";
+    protected static final Map<String, AttributeValue> UNLOCKED_ITEM = createItem(false, false, false);
+    protected static final Map<String, AttributeValue> TRANSIENT_UNAPPLIED_ITEM = createItem(true, true, false);
+    protected static final Map<String, AttributeValue> TRANSIENT_APPLIED_ITEM = createItem(true, true, true);
+    protected static final Map<String, AttributeValue> NON_TRANSIENT_APPLIED_ITEM = createItem(true, false, true);
+
+    private ReadUncommittedIsolationHandlerImpl isolationHandler;
+
+    @Before
+    public void setup() {
+        isolationHandler = new ReadUncommittedIsolationHandlerImpl();
+    }
+
+    private static Map<String, AttributeValue> createItem(boolean isLocked, boolean isTransient, boolean isApplied) {
+        Map<String, AttributeValue> item = new HashMap<String, AttributeValue>();
+        if (isLocked) {
+            item.put(Transaction.AttributeName.TXID.toString(), new AttributeValue(TX_ID));
+            item.put(Transaction.AttributeName.DATE.toString(), new AttributeValue().withS(""));
+            if (isTransient) {
+                item.put(Transaction.AttributeName.TRANSIENT.toString(), new AttributeValue().withS(""));
+            }
+            if (isApplied) {
+                item.put(Transaction.AttributeName.APPLIED.toString(), new AttributeValue().withS(""));
+            }
+        }
+        if (!isTransient) {
+            item.put("attr1", new AttributeValue().withS("some value"));
+        }
+        item.putAll(KEY);
+        return item;
+    }
+
+    @Test
+    public void handleItemReturnsNullForNullItem() {
+        assertNull(isolationHandler.handleItem(null, null, TABLE_NAME));
+    }
+
+    @Test
+    public void handleItemReturnsItemForUnlockedItem() {
+        assertEquals(UNLOCKED_ITEM, isolationHandler.handleItem(UNLOCKED_ITEM, null, TABLE_NAME));
+    }
+
+    @Test
+    public void handleItemReturnsNullForTransientUnappliedItem() {
+        assertNull(isolationHandler.handleItem(TRANSIENT_UNAPPLIED_ITEM, null, TABLE_NAME));
+    }
+
+    @Test
+    public void handleItemReturnsNullForTransientAppliedItem() {
+        assertEquals(TRANSIENT_APPLIED_ITEM, isolationHandler.handleItem(TRANSIENT_APPLIED_ITEM, null, TABLE_NAME));
+    }
+
+    @Test
+    public void handleItemReturnsItemForNonTransientAppliedItem() {
+        assertEquals(NON_TRANSIENT_APPLIED_ITEM, isolationHandler.handleItem(NON_TRANSIENT_APPLIED_ITEM, null, TABLE_NAME));
+    }
+
+}


### PR DESCRIPTION
Adding support for BatchGetItems/Scan/Query

Created a ReadIsolationHandler interface that takes an item
and handles it according to the isolation level of the handler.
There are two implementations of ReadIsolationHandlers:
* ReadCommittedIsolationHandlerImpl will only return a
committed item (possibly an older version stored in the items table).
The logic for this class was refactored from
Transaction.getItemCommitted(...).
* ReadUncommittedIsolationHandlerImpl only removes transient items.

The ReadIsolationHandlers are used to support batchGetItems, scan, and
query in the TransactionManagerDynamoDBFacade at the UNCOMMITTED and
COMMITTED isolation levels.